### PR TITLE
make HEALTH message more graceful when `$BEASTHOST` cannot be resolved

### DIFF
--- a/rootfs/scripts/healthcheck.sh
+++ b/rootfs/scripts/healthcheck.sh
@@ -1,4 +1,3 @@
-
 #!/command/with-contenv bash
 #shellcheck shell=bash
 

--- a/rootfs/scripts/healthcheck.sh
+++ b/rootfs/scripts/healthcheck.sh
@@ -1,3 +1,4 @@
+
 #!/command/with-contenv bash
 #shellcheck shell=bash
 
@@ -6,7 +7,7 @@ EXITCODE=0
 
 # check pw-feeder to beasthost connection
 echo -n "pw-feeder connected to $BEASTHOST:$BEASTPORT: "
-if ! ss --tcp --processes state established dst "$BEASTHOST" \&\& dport "$BEASTPORT" | grep pw-feeder > /dev/null 2>&1; then
+if ! ss --tcp --processes state established dst "$BEASTHOST" \&\& dport "$BEASTPORT" 2>/dev/null| grep -q pw-feeder; then
     EXITCODE=1
     echo "FAIL"
 else
@@ -15,7 +16,7 @@ fi
 
 # check pw-feeder to plane.watch BEAST connection
 echo -n "pw-feeder connected to $PW_BEAST_ENDPOINT: "
-if ! ss --tcp --processes state established dst "$PW_BEAST_ENDPOINT" | grep pw-feeder > /dev/null 2>&1; then
+if ! ss --tcp --processes state established dst "$PW_BEAST_ENDPOINT" 2>/dev/null| grep -q pw-feeder; then
     EXITCODE=1
     echo "FAIL"
 else
@@ -27,7 +28,7 @@ if [[ "${ENABLE_MLAT,,}" == "true" ]]; then
 
     # check mlat-client to beasthost connection
     echo -n "mlat-client connected to $BEASTHOST:$BEASTPORT: "
-    if ! ss --tcp --processes state established dst "$BEASTHOST" \&\& dport "$BEASTPORT" | grep mlat-client > /dev/null 2>&1; then
+    if ! ss --tcp --processes state established dst "$BEASTHOST" \&\& dport "$BEASTPORT" 2>/dev/null | grep -q mlat-client; then
         EXITCODE=1
         echo "FAIL"
     else
@@ -36,7 +37,7 @@ if [[ "${ENABLE_MLAT,,}" == "true" ]]; then
 
     # check mlat-client to pw-feeder connection
     echo -n "mlat-client connected to pw-client ($MLATSERVERHOST:$MLATSERVERPORT): "
-    if ! ss --tcp --processes state established dst "$MLATSERVERHOST" \&\& dport "$MLATSERVERPORT" | grep mlat-client > /dev/null 2>&1; then
+    if ! ss --tcp --processes state established dst "$MLATSERVERHOST" \&\& dport "$MLATSERVERPORT" 2>/dev/null| grep -q mlat-client; then
         EXITCODE=1
         echo "FAIL"
     else
@@ -45,7 +46,7 @@ if [[ "${ENABLE_MLAT,,}" == "true" ]]; then
 
     # check mlat-client to pw-feeder connection
     echo -n "pw-feeder connected to mlat-client: "
-    if ! ss --tcp --processes state established src "$MLATSERVERHOST" \&\& sport "$MLATSERVERPORT" | grep pw-feeder > /dev/null 2>&1; then
+    if ! ss --tcp --processes state established src "$MLATSERVERHOST" \&\& sport "$MLATSERVERPORT" 2>/dev/null| grep -q pw-feeder; then
         EXITCODE=1
         echo "FAIL"
     else
@@ -54,7 +55,7 @@ if [[ "${ENABLE_MLAT,,}" == "true" ]]; then
 
     # check pw-feeder to plane.watch MLAT connection
     echo -n "pw-feeder connected to $PW_MLAT_ENDPOINT: "
-    if ! ss --tcp --processes state established dst "$PW_MLAT_ENDPOINT" | grep pw-feeder > /dev/null 2>&1; then
+    if ! ss --tcp --processes state established dst "$PW_MLAT_ENDPOINT" 2>/dev/null| grep -q pw-feeder; then
         EXITCODE=1
         echo "FAIL"
     else


### PR DESCRIPTION
Fix for cosmetic issue that occurs when using a name for `$BEASTHOST` and this Beast host cannot be resolved. This occurs, for example, when `$BEASTHOST` is a container name, and that container isn't running. 

Old behavior was to show the error output of `ss` across multiple lines in the HEALTH message; new behavior is to simply say it's in FAIL state.  There was no need for this verbosity, which makes the health status hard to read: the status message itself already indicates that there is a connection issue.

Error message before fix:
```text
pw-feeder connected to ultrafeeder:30005: Error: an inet prefix is expected rather than "ultrafeeder".
Cannot parse dst/src address.
FAIL
pw-feeder connected to feed.push.plane.watch:12345: FAIL
mlat-client connected to ultrafeeder:30005: Error: an inet prefix is expected rather than "ultrafeeder".
Cannot parse dst/src address.
FAIL
mlat-client connected to pw-client (127.0.0.1:12346): OK
pw-feeder connected to mlat-client: OK
pw-feeder connected to feed.push.plane.watch:12346: OK
```

Error message after fix:
```text
pw-feeder connected to ultrafeeder:30005: FAIL
pw-feeder connected to feed.push.plane.watch:12345: FAIL
mlat-client connected to ultrafeeder:30005: FAIL
mlat-client connected to pw-client (127.0.0.1:12346): OK
pw-feeder connected to mlat-client: OK
pw-feeder connected to feed.push.plane.watch:12346: OK
```