### PR TITLE
Update docker images to recent and use github native runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,8 @@ jobs:
       id-token: write
     with:
       push_enabled: true
-      push_destinations: ghcr.io;dockerhub
+      push_destinations: ghcr.io
+      #;dockerhub
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}
       # dockerhub_profile: planewatch
@@ -56,4 +57,4 @@ jobs:
       # dockerhub_username: mikenye
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      #dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,4 +56,4 @@ jobs:
       dockerhub_username: mikenye
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
-      #dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
   deploy:
     name: Deploy
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@main
     with:
       push_enabled: true
       push_destinations: ghcr.io;dockerhub
@@ -49,7 +49,6 @@ jobs:
       dockerhub_profile: planewatch
       dockerhub_repo: plane-watch
       dockerhub_username: mikenye
-      get_version_method: file_in_container:file=/PW_FEEDER_VERSION
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,12 @@ jobs:
       id-token: write
     with:
       push_enabled: true
-      push_destinations: ghcr.io
-      #;dockerhub
+      push_destinations: ghcr.io;dockerhub
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}
-      # dockerhub_profile: planewatch
-      # dockerhub_repo: plane-watch
-      # dockerhub_username: mikenye
+      dockerhub_profile: planewatch
+      dockerhub_repo: plane-watch
+      dockerhub_username: mikenye
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
       #dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,9 +46,9 @@ jobs:
       push_destinations: ghcr.io;dockerhub
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}
-      dockerhub_profile: planewatch
-      dockerhub_repo: plane-watch
-      dockerhub_username: mikenye
+      # dockerhub_profile: planewatch
+      # dockerhub_repo: plane-watch
+      # dockerhub_username: mikenye
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
   deploy:
     name: Deploy
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@main
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     with:
       push_enabled: true
       push_destinations: ghcr.io;dockerhub

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -23,7 +23,8 @@ jobs:
 
   test-build:
     name: Test
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/build_and_push_image.yml@main
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@main
     with:
       push_enabled: false
-      get_version_method: file_in_container:file=/PW_FEEDER_VERSION
+      ghcr_repo_owner: ${{ github.repository_owner }}
+      ghcr_repo: ${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,8 @@ RUN set -x && \
     # Install packages
     apt-get update && \
     apt-get install --no-install-recommends -y \
-    ${KEPT_PACKAGES[@]} \
-    ${TEMP_PACKAGES[@]} \
+    "${KEPT_PACKAGES[@]}" \
+    "${TEMP_PACKAGES[@]}" \
     && \
     # install CA cert helper script: download
     curl -o /tmp/install_ca_certs.sh -s https://raw.githubusercontent.com/plane-watch/pw-feeder/main/install_ca_certs.sh && \
@@ -78,7 +78,7 @@ RUN set -x && \
     curl -o /tmp/deploy-s6-overlay.sh -s https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/deploy-s6-overlay-v3.sh && \
     bash /tmp/deploy-s6-overlay.sh && \
     # Clean-up
-    apt-get remove -y ${TEMP_PACKAGES[@]} && \
+    apt-get remove -y "${TEMP_PACKAGES[@]}" && \
     apt-get autoremove -y && \
     rm -rf /src/* /tmp/* /var/lib/apt/lists/* && \
     find /var/log -type f -exec truncate --size=0 {} \; && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-bullseye AS pw_feeder_builder
+FROM golang:1.24.4-bookworm AS pw_feeder_builder
 
 ARG PW_FEEDER_BRANCH
 
@@ -18,7 +18,7 @@ RUN set -x && \
     echo "${PW_FEEDER_BRANCH:-$LATEST_TAG}" > /PW_FEEDER_VERSION
 
 
-FROM debian:bullseye-20240423
+FROM debian:bookworm-20250630
 
 ENV BEASTPORT=30005 \
     MLATSERVERHOST=127.0.0.1 \
@@ -59,14 +59,14 @@ RUN set -x && \
     # Install packages
     apt-get update && \
     apt-get install --no-install-recommends -y \
-        ${KEPT_PACKAGES[@]} \
-        ${TEMP_PACKAGES[@]} \
-        && \
+    ${KEPT_PACKAGES[@]} \
+    ${TEMP_PACKAGES[@]} \
+    && \
     # install CA cert helper script: download
     curl -o /tmp/install_ca_certs.sh -s https://raw.githubusercontent.com/plane-watch/pw-feeder/main/install_ca_certs.sh && \
     # install CA cert helper script: remove sudo (we're already root)
     sed -i 's/sudo //g' /tmp/install_ca_certs.sh && \
-    # install CA cert helper script: run 
+    # install CA cert helper script: run
     bash /tmp/install_ca_certs.sh && \
     # mlat-client
     git clone --depth 1 --single-branch https://github.com/mutability/mlat-client.git "/src/mlat-client" && \


### PR DESCRIPTION
For your consideration, this PR does the following:

* Bumps go-lang to the most recent stable version (1.22.3-bullseye -> 1.24.4-bookworm)
* Bumps the base OS to the most recent stable version (debian-bullseye-20240403 -> debian-bookworm-20250630)
* Moves the GitHub CI from `sdre/common-workflows/build-and-push-image.yml` to `sdre/common-workflows/sdre.yml`. 

To elaborate further on the last change, this removes the dependency on using QEMU during the build pipeline to emulate ARM based CPUs to using Github's own ARM runners. This should substantially decrease build time. I wasn't able to see what your previous build times were, but on my forked repo I built armhf, aarch64 and AMD64 in just over 3 minutes. I expect, given my experience, this is easily a 20+ minute time savings.

One thing I was not able to test as I developed the sdre.yml file, and doing the test build for this, is dockerhub pushes. I don't expect that there will be any issues, but the action is untested and I felt it was worth mentioning.